### PR TITLE
Enable threadsafe sampling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,14 @@ set(LINK_LIBS ${CRY_LIBRARIES} ${LINK_LIBS})
 ################################################################################
 
 project(openmc_sources CXX)
+
 add_library(source SHARED source_cosmic_ray_neutrons.cpp)
 add_dependencies(source CRY-1.7)
+find_package(OpenMP)
+if(OPENMP_FOUND)
+  target_compile_options(source PRIVATE ${OpenMP_CXX_FLAGS})
+  target_link_libraries(source ${OpenMP_CXX_FLAGS})
+endif()
+
 find_package(OpenMC REQUIRED HINTS /usr/local/lib)
 target_link_libraries(source OpenMC::libopenmc ${CRY_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,5 +27,6 @@ set(LINK_LIBS ${CRY_LIBRARIES} ${LINK_LIBS})
 
 project(openmc_sources CXX)
 add_library(source SHARED source_cosmic_ray_neutrons.cpp)
+add_dependencies(source CRY-1.7)
 find_package(OpenMC REQUIRED HINTS /usr/local/lib)
 target_link_libraries(source OpenMC::libopenmc ${CRY_LIBRARIES})

--- a/source_cosmic_ray_neutrons.cpp
+++ b/source_cosmic_ray_neutrons.cpp
@@ -86,17 +86,17 @@ public:
     //   std::cout << vect.size() << std::endl;
     // }
 
-    CRYParticle* p = vect[0];
+    CRYParticle* p = vect.back();
     double e = p->ke() * 1e6;
     if(discard) {
       while(e > cutoffenergy) {
         // std::cout << "Discarding particle, looking for particle below cutoff energy" << std::endl;
         delete p;
-        vect.erase(vect.begin());
+        vect.pop_back();
         if(vect.size() == 0) {
           gen->genEvent(&vect);
         }
-        p = vect[0];
+        p = vect.back();
         e = p->ke() * 1e6;
       }
     }
@@ -114,7 +114,7 @@ public:
     delete p;
     // std::cout << particle.E << std::endl;
     // std::cout << particle.r << std::endl;
-    vect.erase(vect.begin());
+    vect.pop_back();
     return particle;
 
   }


### PR DESCRIPTION
These changes allow the CRY-based custom source to work with multiple threads when integrated in OpenMC. The main issue that was preventing multithreading from working properly before was that modifications to the vector of CRYParticles was not protected from race conditions. To fix this, I've enclosed any changes to this vector within a method that gets called from within a `#pragma omp critical` block. I also changed the algorithm to get the last particle out of the vector as this should reduce the number of memory reallocations that need to occur (if you remove an element from the beginning of a `std::vector`, the remainder of the array gets copied to a new memory allocation).

One other change -- in the CMake file, I've added a dependency of the source library on CRY so that it knows to compile CRY first.